### PR TITLE
PB-2852 Use --prefer-lowest when installing deps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - uses: php-actions/composer@v6
         with:
+          args: --prefer-lowest
           php_version: ${{ matrix.php }}
           version: "2.2"
       - run: "composer unit-test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ['7.2', '7.4']
+        php: ['7.2', '7.4', '8.2', '8.3']
     name: run tests @${{ matrix.php }}
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +18,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - uses: php-actions/composer@v6
         with:
+          command: update
           args: --prefer-lowest
           php_version: ${{ matrix.php }}
           version: "2.2"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor/
-.phpunit.result.cache
+/vendor/
+/.phpunit.result.cache
+/composer.lock

--- a/src/Api.php
+++ b/src/Api.php
@@ -201,6 +201,7 @@ class Api
             ->withHeader('Content-Type', 'application/json')
             ->withBody($body);
 
+        /** @var RequestInterface $request */
         return $this->sendRequest($request);
     }
 
@@ -215,6 +216,7 @@ class Api
         $request = $this->requestFactory->createRequest('GET', $this->baseUrl . ltrim($path, '/'))
             ->withHeader('X-Api-Key', $this->apiKey);
 
+        /** @var RequestInterface $request */
         return $this->sendRequest($request);
     }
 


### PR DESCRIPTION
This avoids the scenario where phpunit/phpunit latest is installed which drops support for PHP 7.x